### PR TITLE
Bump to 0.0.6, add npx and fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: ~/repo/node_modules/.bin/tsc
       - run: mkdir ~/junit-oracle
-      - run: JEST_JUNIT_OUTPUT=~/junit-oracle/test-results.xml yarn run test --ci --reporters=default --reporters=jest-junit
+      - run: JEST_JUNIT_OUTPUT=~/junit-oracle/test-results.xml yarn run test -- --ci --reporters=default --reporters=jest-junit
       - store_test_results:
           path: ~/junit-oracle
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ contract MyContract {
 Now, you can compile your contract with:
 
 ```bash
-saddle compile
+npx saddle compile
 ```
 
 `saddle compile` will compile your contracts and store the built output in `./build/contracts.json`. This is the raw output of solc compile.
@@ -64,7 +64,7 @@ saddle compile
 After you've compiled, you can deploy your contracts:
 
 ```bash
-saddle deploy -n development
+npx saddle deploy -n development
 ```
 
 This will deploy your comiled contracts to development (for this, you should have [ganache](https://github.com/trufflesuite/ganache) running). For more information on configuring your deployment for rinkeby or mainnet, see the configuration section below.
@@ -76,7 +76,7 @@ After you have deployed, you will also see the contract address listed in `./bui
 Note: before testing, you currently have to compile your contracts. To run your tests, then, run:
 
 ```bash
-saddle compile && saddle test
+npx saddle compile && npx saddle test
 ```
 
 `saddle test` runs your tests. To add tests, create a directory `/tests` and add some simple tests, e.g.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "eth-saddle",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "description": "Ethereum Smart Contract Saddle",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cli.js",
+  "types": "dist/cli.d.ts",
+  "files": ["dist/**", "saddle.config.js"],
   "repository": "https://github.com/compound-finance/saddle",
   "author": "Compound Labs, Inc.",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,4 +41,7 @@ yargs
   })
   .help()
   .alias('help', 'h')
+  .demandCommand()
+  .recommendCommands()
+  .strict()
   .parse();


### PR DESCRIPTION
This patch simply bumps up the version, fixes the docs to use npx and fixes our CI builds.