### PR TITLE
Bump to 0.0.9 and properly build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coburncoburn @jflatow @hayesgm @maxwolff @torreyatcitty

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",
@@ -22,7 +22,8 @@
     "typescript": "^3.5.1"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "prepare" : "tsc"
   },
   "bin": {
     "saddle": "dist/cli.js"

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -3,7 +3,7 @@ import {getSaddle} from '../../saddle';
 
 import {info, debug, warn, error} from '../logger';
 
-export async function deploy(network: string, contractName: string, contractArgs: string[], verbose: number): Promise<void> {
+export async function deploy(network: string, contractName: string, contractArgs: (string|string[])[], verbose: number): Promise<void> {
 
   let saddle = await getSaddle(network);
 


### PR DESCRIPTION
We properly build before publish via the new publish command. We also bump to 0.0.9 and fix a type definition.