### PR TITLE
Add Tracing Utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/saddle.config.js
+++ b/saddle.config.js
@@ -10,6 +10,7 @@ module.exports = {
   coverage_ignore: [],                                  // List of files to ignore for coverage
   contracts: "contracts/*.sol",                         // Glob to match contract files
   tests: ['**/tests/*.js'],                             // Glob to match test files
+  trace: false,                                         // Compile with debug artifacts
   networks: {                                           // Define configuration for each network
     development: {
       providers: [                                      // How to load provider (processed in order)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,13 +36,13 @@ if (require.main === module) {
     .alias('v', 'verbose')
     .command('compile', 'Compiles all contracts', (yargs) => {
       return yargs
-        .option('coverage', {
-          describe: 'Build contracts for coverage',
+        .option('trace', {
+          describe: 'Build contracts with detailed debug information',
           type: 'boolean',
           default: false
         });
     }, (argv) => {
-      compile(argv.coverage, argv.verbose)
+      compile(argv.trace, argv.verbose)
     })
     .command('deploy <contract>', 'Deploy a contract to given network', (yargs) => {
       return yargs

--- a/src/cli/commands/compile.ts
+++ b/src/cli/commands/compile.ts
@@ -5,18 +5,18 @@ import {mkdirp, writeFile} from '../../file';
 
 import {info, debug, warn, error} from '../logger';
 
-export async function compile(coverage: boolean, verbose: number): Promise<void> {
+export async function compile(trace: boolean, verbose: number): Promise<void> {
   let config = await loadConfig();
 
   const buildDir = config.build_dir;
   let outFile, solc;
 
-  if (!coverage) {
+  if (trace || config.trace) {
+    outFile = `${buildDir}/contracts-trace.json`;
+    solc = `${config.solc} --combined-json bin,bin-runtime,abi,metadata,asm,srcmap,srcmap-runtime --metadata-literal --optimize ${config.solc_args.join(" ")} ${config.contracts}`;
+  } else {
     outFile = `${buildDir}/contracts.json`;
     solc = `${config.solc} --combined-json bin,abi,metadata --metadata-literal --optimize ${config.solc_args.join(" ")} ${config.contracts}`;
-  } else {
-    outFile = `${buildDir}/coverage-contracts.json`;
-    solc = `${config.solc} --combined-json bin,bin-runtime,abi,metadata,asm,srcmap,srcmap-runtime --metadata-literal --optimize ${config.solc_args.join(" ")} ${config.contracts}`;
   }
 
   info(`Compiling contracts ${config.contracts} with ${config.solc} to ${outFile}...`, verbose);

--- a/src/saddle.ts
+++ b/src/saddle.ts
@@ -5,6 +5,7 @@ import {ABIItem} from 'web3-utils';
 import {Contract, SendOptions, CallOptions} from 'web3-eth-contract';
 import {describeProvider} from './utils';
 import { TransactionReceipt } from 'web3-eth';
+import { buildTracer, TraceOptions } from './trace';
 
 export interface Saddle {
   account: string,
@@ -19,6 +20,7 @@ export interface Saddle {
   web3: Web3
   send: (sendable: any, sendOptions?: any) => Promise<any>
   call: (callable: any, callOptions?: any) => Promise<any>
+  trace: (receipt: TransactionReceipt, options: TraceOptions) => Promise<any>
 }
 
 export async function getSaddle(network, coverage=false): Promise<Saddle> {
@@ -106,6 +108,7 @@ export async function getSaddle(network, coverage=false): Promise<Saddle> {
     send: send,
     call: call,
     getContract: getContractInt,
-    getContractAt: getContractAtInt
+    getContractAt: getContractAtInt,
+    trace: await buildTracer(network_config)
   };
 }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,0 +1,163 @@
+import { NetworkConfig } from './config';
+import { TraceCollector, parseSourceMap } from '@0x/sol-tracing-utils';
+import { TransactionReceipt } from 'web3-eth';
+import { stripHexPrefix } from 'ethereumjs-util';
+import chalk from 'chalk';
+import Web3 from 'web3';
+import { augmentLogs } from './trace/descriptor';
+
+interface Trace {
+  gas: number,
+  returnValue: any,
+  structLogs: StructLog[]
+}
+
+export interface TraceInfo {
+  lastLog: undefined | StructLog,
+  inv: InversionMap
+}
+
+export interface InversionItem {
+  operation: string
+  inputs: string[]
+}
+
+export interface InversionMap {
+  [key: string]: InversionItem[]
+}
+
+export interface StructLog {
+  depth: number,
+  error: string,
+  gas: number,
+  gasCost: number,
+  memory: null | string[],
+  op: string,
+  pc: number,
+  stack: string[],
+  storage: {[key: string]: string}
+  source: undefined | any
+  sourceLine: undefined | string,
+  desc: undefined | string
+  lastDesc: undefined | string
+  sha: object
+  show: undefined | (() => void)
+}
+
+export interface TraceOptions {
+  constants?: {[key: string]: string},
+  onTrace?: (Trace) => Promise<void>,
+  preFilter?: undefined | ((log: StructLog) => boolean),
+  postFilter?: undefined | ((log: StructLog) => boolean),
+  execLog?: undefined | ((log: StructLog, info: TraceInfo) => Promise<void>)
+  exec?: undefined | ((logs: StructLog[], info: TraceInfo) => Promise<void>)
+}
+
+function rpc(web3, request) {
+  return new Promise((okay, fail) => web3.currentProvider.send(request, (err, res) => err ? fail(err) : okay(res)));
+}
+
+async function traceTransaction(web3, txHash, traceParams={}) {
+  let {result} = <{result: Trace}>await rpc(web3, {method: 'debug_traceTransaction', params: [txHash, traceParams]});
+
+  return result;
+}
+
+function getSource(offset, sourceFile) {
+  let lines = sourceFile.slice(offset.location.start.line - 1, offset.location.end.line);
+  let startCol = offset.location.start.column;
+  let endCol = offset.location.end.column;
+  let color = chalk.blueBright;
+  let sourceLine = offset.location.start.line === offset.location.end.line ?
+    `${offset.fileName}:${offset.location.start.line}[${offset.location.start.column}-${offset.location.end.column}]` :
+    `${offset.fileName}:${offset.location.start.line}[${offset.location.start.column}]-${offset.location.end.line}[${offset.location.end.column}]`;
+
+  let source = lines.reduce((result, line, i) => {
+    let first = i === 0;
+    let last = i === lines.length - 1;
+    if (first && last) {
+      // Single line
+      return result + line.slice(0, startCol) + color(line.slice(startCol, endCol)) + line.slice(endCol);
+    } else {
+      if (first) {
+        return result + line.slice(0, startCol) + color(line.slice(startCol));
+      } else if (last) {
+        return result + color(line.slice(0, endCol)) + line.slice(endCol);
+      } else {
+        return result + color(line)
+      }
+    }
+  }, '');
+
+  return {
+    source,
+    sourceLine
+  };
+}
+
+export async function buildTracer(network_config: NetworkConfig) {
+  let contractsData, traceCollector;
+  if (network_config.artifactAdapter) {
+    contractsData = await network_config.artifactAdapter.collectContractsDataAsync();
+    traceCollector = new TraceCollector(network_config.artifactAdapter, true, <any>null);
+  }
+
+  return async function trace(receipt: TransactionReceipt, traceOpts: TraceOptions): Promise<any> {
+    let pcToSourceRange, inverted;
+    if (traceCollector) {
+      let address = receipt.contractAddress || receipt.to;
+      let isContractCreation = receipt.contractAddress !== null;
+      let bytecode = await network_config.web3.eth.getCode(address);
+      let contractData = await traceCollector.getContractDataByTraceInfoIfExistsAsync(address, bytecode, isContractCreation);
+
+      if (!contractData) {
+        throw new Error(`Failed to find contract data for given bytecode at ${address}`);
+      }
+
+      const bytecodeHex = stripHexPrefix(bytecode);
+      const sourceMap = isContractCreation ? contractData.sourceMap : contractData.sourceMapRuntime;
+      pcToSourceRange = parseSourceMap(contractData.sourceCodes, sourceMap, bytecodeHex, contractData.sources);
+      inverted = Object.entries(contractData.sources).reduce((acc, [id, name]) => {
+        return {
+          ...acc,
+          [<string>name]: contractData.sourceCodes[<string>id].split("\n")
+        };
+      }, {});
+    };
+
+    let trace = await traceTransaction(network_config.web3, receipt.transactionHash, {});
+
+    if (traceOpts.onTrace) {
+      await traceOpts.onTrace(trace);
+    }
+
+    let {logs: augmentedLogs, info: info} = augmentLogs(trace.structLogs, traceOpts.constants || {});
+    let filteredLogs = traceOpts.preFilter ? augmentedLogs.filter(traceOpts.preFilter) : augmentedLogs;
+
+    if (pcToSourceRange && inverted) {
+      filteredLogs = filteredLogs.map((log, i) => {
+        let offset = pcToSourceRange[log.pc];
+        let sourceFile = inverted[offset.fileName];
+
+        return {
+          ...log,
+          ...getSource(offset, sourceFile)
+        }
+      });
+    }
+
+    let postFilteredLogs = traceOpts.postFilter ? filteredLogs.filter(traceOpts.postFilter) : filteredLogs;
+
+    if (traceOpts.execLog !== undefined) {
+      let {execLog} = traceOpts;
+
+      await Promise.all(postFilteredLogs.map((log) => execLog(log, info)));
+    }
+
+    if (traceOpts.exec !== undefined) {
+      await traceOpts.exec(postFilteredLogs, info);
+    }
+
+    return postFilteredLogs;
+  }
+}

--- a/src/trace/descriptor.ts
+++ b/src/trace/descriptor.ts
@@ -1,0 +1,109 @@
+import { InversionMap, StructLog, TraceInfo } from '../trace';
+import { describeOperation } from './operator';
+import { chunk, pad, trimZero, trim0x } from './utils';
+import Web3 from 'web3';
+import chalk from 'chalk';
+
+let web3 = new Web3();
+
+export interface Desc {
+  op: string,
+  inputs: string[],
+  outputs: string[]
+}
+
+let seen = {};
+
+export function showInv(inv: InversionMap, key: string): string {
+  if (key.length > 64) {
+    let res = chunk(key, 64).map((chk) => {
+      return doShowInv(inv, <string>chk);
+    });
+
+    return `CONCAT(${res.join(',')})`;
+  } else {
+    return doShowInv(inv, key);
+  }
+}
+
+function doShowInv(inv: InversionMap, key: string): string {
+  let res;
+
+  if (seen[key]) {
+    return seen[key]
+  } else if (parseInt(key, 16) < 10000) { // ignore small numbers
+    res = `0x${trimZero(key)}`;
+  } else if (inv[key] && inv[key][0]) {
+    // For now, we'll just use the first if we have multiple
+    // This is probably good since it's when the value first arrived
+    const el = inv[key][0];
+    if (el.inputs.length > 0) {
+      const inputs = el.inputs.map((input) => showInv(inv, input))
+      res = `${el.operation}(${inputs.join(',')})`;
+    } else {
+      return el.operation;
+    }
+  } else {
+    res = `0x${trimZero(key)}`;
+  }
+
+  seen[key] = res;
+  return res;
+}
+
+export function addInv(inv: InversionMap, op: string, inputs: string[], outputs: string[]): InversionMap {
+  return outputs.reduce((inv, output) => {
+    let curr = inv[output] || [];
+
+    return {
+      ...inv,
+      [output]: [
+        ...curr,
+        {
+          operation: op,
+          inputs: inputs
+        }
+      ]
+    };
+  }, inv);
+}
+
+export function augmentLogs(logs, constants) {
+  const inv = Object.entries(constants).reduce((inv, [k, v] ) => {
+    const key = pad(trim0x(v)).toLowerCase();
+
+    return {
+      ...inv,
+      [key]: [
+        {
+          operation: k,
+          inputs: []
+        }
+      ]
+    };
+  }, {});
+
+  return logs.reduce(({logs, info}, log, i, allLogs) => {
+    const nextLog: StructLog | undefined = allLogs[i + 1];
+    const nextStack = nextLog ? nextLog.stack : undefined;
+
+    let {log: nLog, info: nInfo} = describeOperation(log, nextStack || [], info);
+
+    nLog.lastDesc = info.lastLog ? info.lastLog.desc : undefined;
+    nLog.show = function() {
+      if (log.source) {
+        console.log(`${log.source.trim()}\n↓\n${chalk.blueBright(log.desc)}`);
+      } else {
+        console.log(chalk.blueBright(log.desc));
+      }
+    }
+
+    return {
+      logs: [...logs, nLog],
+      info: {
+        ...nInfo,
+        lastLog: nLog
+      }
+    };
+  }, <{logs: StructLog[], info: TraceInfo}>{logs: [], info: {lastLog: undefined, inv}});
+}

--- a/src/trace/operator.ts
+++ b/src/trace/operator.ts
@@ -1,0 +1,332 @@
+import { StructLog, TraceInfo } from '../trace';
+import { Desc, addInv, showInv } from './descriptor';
+import { last, lastN } from './utils';
+
+function buildDesc(desc: Desc, info: TraceInfo): { inputs: string[], outputs: string[], desc: string } {
+  let inputs = '';
+  let outputs = '';
+
+  if (desc.inputs.length > 0) {
+    const mappedInputs = desc.inputs.map((input) => showInv(info.inv, input));
+
+    inputs = `[${mappedInputs.join(',')}]`
+  }
+
+  if (desc.outputs.length > 0) {
+    outputs = `-> ${desc.outputs.join(',')}`;
+  }
+
+  return {
+    inputs: desc.inputs,
+    outputs: desc.outputs,
+    desc: `${desc.op}${inputs}${outputs}`
+  };
+}
+
+function buildOpDesc(log: StructLog, nextStack: string[], info: TraceInfo, opInfo: OpInfo) {
+  const desc: Desc = {
+    op: log.op,
+    inputs:  lastN(log.stack, opInfo.inputs),
+    outputs: lastN(nextStack, opInfo.outputs)
+  };
+
+  let inv = info.inv;
+
+  if (opInfo.addInv) {
+    inv = addInv(info.inv, log.op, desc.inputs, desc.outputs);
+  }
+
+  return {
+    log: {
+      ...log,
+      ...buildDesc(desc, info),
+    },
+    info: {
+      ...info,
+      inv
+    }
+  }
+}
+
+function pushFn(n: number) {
+  return function(log: StructLog, nextStack: string[], info: TraceInfo) {
+    return {
+      log: {
+        ...log,
+        ...buildDesc({
+          op: log.op,
+          inputs: lastN(nextStack, 1),
+          outputs: []
+        }, info)
+      },
+      info: {
+        ...info,
+        inv: addInv(info.inv, log.op, lastN(nextStack, 1), [])
+      }
+    }
+  }
+}
+
+function swapFn(n: number) {
+  return function(log: StructLog, nextStack: string[], info: TraceInfo) {
+    return {
+      log: {
+        ...log,
+        ...buildDesc({
+          op: log.op,
+          inputs: [last(nextStack, 1)],
+          outputs: [last(nextStack, n)]
+        }, info)
+      },
+      info
+    }
+  };
+}
+
+function dupFn(n: number) {
+  return function(log: StructLog, nextStack: string[], info: TraceInfo) {
+    return {
+      log: {
+        ...log,
+        ...buildDesc({
+          op: log.op,
+          inputs: lastN(nextStack, n),
+          outputs: lastN(nextStack, n)
+        }, info)
+      },
+      info
+    }
+  };
+}
+
+function logFn(n: number) {
+  return function(log: StructLog, nextStack: string[], info: TraceInfo) {
+    return {
+      log: {
+        ...log,
+        ...buildDesc({
+          op: log.op,
+          inputs: lastN(log.stack, n),
+          outputs: []
+        }, info)
+      },
+      info
+    }
+  };
+}
+
+function sha(log: StructLog, nextStack: string[], info: TraceInfo) {
+  let memory = log.memory || [];
+  const memStart = parseInt(last(log.stack, 1), 16);
+  const memEnd = parseInt(last(log.stack, 2), 16);
+
+  let inputs = [memory.join('').slice(memStart * 2, memEnd * 2)];
+  let outputs = lastN(nextStack, 1);
+  let inv = addInv(info.inv, log.op, inputs, outputs);
+
+  return {
+    log: {
+      ...log,
+      ...buildDesc({op: log.op, inputs, outputs}, info),
+      sha: {
+        ...log.sha,
+        [inputs[0]]: outputs[0]
+      }
+    },
+    info: {
+      ...info,
+      inv
+    }
+  };
+}
+
+// SLOAD inv?
+// xinv = addInv(inv, log.op, desc.inputs, desc.outputs);
+
+interface OpInfo {
+  inputs: number,
+  outputs: number,
+  addInv?: boolean
+}
+
+type DescFn = (log: StructLog, nextStack: string[], info: TraceInfo) => {log: StructLog, info: TraceInfo}
+
+const opcodes: {[name: string]: OpInfo | DescFn | null } = {
+  // 0x0 range - arithmetic ops
+  // name, baseCost, async
+  STOP: { inputs: 0, outputs: 0 },
+  ADD: { inputs: 2, outputs: 1, addInv: true },
+  MUL: { inputs: 2, outputs: 1, addInv: true },
+  SUB: { inputs: 2, outputs: 1, addInv: true },
+  DIV: { inputs: 2, outputs: 1, addInv: true },
+  SDIV: { inputs: 2, outputs: 1, addInv: true },
+  MOD: { inputs: 2, outputs: 1, addInv: true },
+  SMOD: { inputs: 2, outputs: 1, addInv: true },
+  ADDMOD: { inputs: 3, outputs: 1, addInv: true },
+  MULMOD: { inputs: 3, outputs: 1, addInv: true },
+  EXP: { inputs: 2, outputs: 1, addInv: true },
+  SIGNEXTEND: { inputs: 2, outputs: 1, addInv: true },
+
+  // 0x10 range - bit ops
+  LT: { inputs: 2, outputs: 1 },
+  GT: { inputs: 2, outputs: 1 },
+  SLT: { inputs: 2, outputs: 1 },
+  SGT: { inputs: 2, outputs: 1 },
+  EQ: { inputs: 2, outputs: 1 },
+  ISZERO: { inputs: 1, outputs: 1 },
+  AND: { inputs: 2, outputs: 1, addInv: true },
+  OR: { inputs: 2, outputs: 1, addInv: true },
+  XOR: { inputs: 2, outputs: 1, addInv: true },
+  NOT: { inputs: 1, outputs: 1, addInv: true },
+  BYTE: { inputs: 2, outputs: 1, addInv: true },
+  SHL: { inputs: 2, outputs: 1, addInv: true },
+  SHR: { inputs: 2, outputs: 1, addInv: true },
+  SAR: { inputs: 2, outputs: 1, addInv: true },
+
+  // 0x20 range - crypto
+  SHA3: sha,
+
+  // 0x30 range - closure state
+  ADDRESS: { inputs: 0, outputs: 1 },
+  BALANCE: { inputs: 1, outputs: 1 },
+  ORIGIN: { inputs: 0, outputs: 1 },
+  CALLER: { inputs: 0, outputs: 1 },
+  CALLVALUE: { inputs: 0, outputs: 1 },
+  CALLDATALOAD: { inputs: 1, outputs: 1 },
+  CALLDATASIZE: { inputs: 0, outputs: 1 },
+  CALLDATACOPY: { inputs: 3, outputs: 0 },
+  CODESIZE: { inputs: 0, outputs: 1 },
+  CODECOPY: { inputs: 3, outputs: 0 },
+  GASPRICE: { inputs: 0, outputs: 1 },
+  EXTCODESIZE: { inputs: 1, outputs: 1 },
+  EXTCODECOPY: { inputs: 4, outputs: 0 },
+  RETURNDATASIZE: { inputs: 0, outputs: 1 },
+  RETURNDATACOPY: { inputs: 3, outputs: 0 },
+  EXTCODEHASH: null,
+
+  // '0x40' range - block operations
+  BLOCKHASH: { inputs: 1, outputs: 1 },
+  COINBASE: { inputs: 0, outputs: 1 },
+  TIMESTAMP: { inputs: 0, outputs: 1 },
+  NUMBER: { inputs: 0, outputs: 1 },
+  DIFFICULTY: { inputs: 0, outputs: 1 },
+  GASLIMIT: { inputs: 0, outputs: 1 },
+
+  // 0x50 range - 'storage' and execution
+  POP: { inputs: 1, outputs: 0 },
+  MLOAD: { inputs: 1, outputs: 1 },
+  MSTORE: { inputs: 2, outputs: 0 },
+  MSTORE8: { inputs: 2, outputs: 0 },
+  SLOAD: { inputs: 1, outputs: 1 },
+  SSTORE: { inputs: 2, outputs: 0 },
+  JUMP: { inputs: 1, outputs: 0 },
+  JUMPI: { inputs: 2, outputs: 0 },
+  PC: { inputs: 0, outputs: 1 },
+  MSIZE: { inputs: 0, outputs: 1 },
+  GAS: { inputs: 0, outputs: 1 },
+  JUMPDEST: { inputs: 0, outputs: 0 },
+
+  // 0x60, range
+  PUSH1: pushFn(1),
+  PUSH2: pushFn(2),
+  PUSH3: pushFn(3),
+  PUSH4: pushFn(4),
+  PUSH5: pushFn(5),
+  PUSH6: pushFn(6),
+  PUSH7: pushFn(7),
+  PUSH8: pushFn(8),
+  PUSH9: pushFn(9),
+  PUSH10: pushFn(10),
+  PUSH11: pushFn(11),
+  PUSH12: pushFn(12),
+  PUSH13: pushFn(13),
+  PUSH14: pushFn(14),
+  PUSH15: pushFn(15),
+  PUSH16: pushFn(16),
+  PUSH17: pushFn(17),
+  PUSH18: pushFn(18),
+  PUSH19: pushFn(19),
+  PUSH20: pushFn(20),
+  PUSH21: pushFn(21),
+  PUSH22: pushFn(22),
+  PUSH23: pushFn(23),
+  PUSH24: pushFn(24),
+  PUSH25: pushFn(25),
+  PUSH26: pushFn(26),
+  PUSH27: pushFn(27),
+  PUSH28: pushFn(28),
+  PUSH29: pushFn(29),
+  PUSH30: pushFn(30),
+  PUSH31: pushFn(31),
+  PUSH32: pushFn(32),
+
+  DUP1: dupFn(1),
+  DUP2: dupFn(2),
+  DUP3: dupFn(3),
+  DUP4: dupFn(4),
+  DUP5: dupFn(5),
+  DUP6: dupFn(6),
+  DUP7: dupFn(7),
+  DUP8: dupFn(8),
+  DUP9: dupFn(9),
+  DUP10: dupFn(10),
+  DUP11: dupFn(11),
+  DUP12: dupFn(12),
+  DUP13: dupFn(13),
+  DUP14: dupFn(14),
+  DUP15: dupFn(15),
+  DUP16: dupFn(16),
+
+  SWAP1: swapFn(1),
+  SWAP2: swapFn(2),
+  SWAP3: swapFn(3),
+  SWAP4: swapFn(4),
+  SWAP5: swapFn(5),
+  SWAP6: swapFn(6),
+  SWAP7: swapFn(7),
+  SWAP8: swapFn(8),
+  SWAP9: swapFn(9),
+  SWAP10: swapFn(10),
+  SWAP11: swapFn(11),
+  SWAP12: swapFn(12),
+  SWAP13: swapFn(13),
+  SWAP14: swapFn(14),
+  SWAP15: swapFn(15),
+  SWAP16: swapFn(16),
+
+  LOG0: logFn(0),
+  LOG1: logFn(1),
+  LOG2: logFn(2),
+  LOG3: logFn(3),
+  LOG4: logFn(4),
+
+  // '0xf0' range - closures
+  CREATE: { inputs: 3, outputs: 1 },
+  CALL: { inputs: 7, outputs: 1 },
+  CALLCODE: { inputs: 7, outputs: 1 },
+  RETURN: { inputs: 2, outputs: 0 },
+  DELEGATECALL: { inputs: 6, outputs: 1 },
+  CREATE2: null,
+  STATICCALL: { inputs: 6, outputs: 1 },
+  REVERT: { inputs: 2, outputs: 0 },
+
+  // '0x70', range - other
+  INVALID: null,
+  SELFDESTRUCT: { inputs: 1, outputs: 0 },
+
+  // istanbul (double check)
+  CHAINID: { inputs: 0, outputs: 1 },
+  SELFBALANCE: { inputs: 0, outputs: 1 },
+}
+
+export function describeOperation(log: StructLog, nextStack: string[], info: TraceInfo): { log: StructLog, info: TraceInfo } {
+  let opinfo = opcodes[log.op];
+
+  if (!opinfo) {
+    return { log, info };
+  } else if (typeof(opinfo) === 'function') {
+    return opinfo(log, nextStack, info);
+  } else {
+    return buildOpDesc(log, nextStack, info, opinfo);
+  }
+}

--- a/src/trace/utils.ts
+++ b/src/trace/utils.ts
@@ -1,0 +1,43 @@
+
+export function last(arr, n=1) {
+  return arr[arr.length - n];
+}
+
+export function lastN(arr, n=1) {
+  return arr.slice(arr.length - n);
+}
+
+export function chunk<T>(arr, size) {
+  let i = 0;
+  let chunks: T[] = [];
+
+  while (i < arr.length) {
+    chunks.push(arr.slice(i, i+size));
+    i+=size;
+  }
+
+  return chunks;
+}
+
+export function trimZero(num) {
+  let i = 0;
+  while (num[i] === '0') {
+    i++;
+  }
+
+  return num.slice(i);
+}
+
+export function trim0x(num) {
+  if (num.slice(0, 2) === '0x') {
+    return num.slice(2,);
+  } else {
+    return num;
+  }
+}
+
+export function pad(val, align=32) {
+  let padLength = align - ( val.length % align );
+
+  return [...Array(padLength).keys()].map((_) => '0').join('') + val;
+}


### PR DESCRIPTION
The patch adds tracing utilities, which allows us to analyze receipts with full syntactic analysis matched to op codes. For example, if the code looked like this:

```
return balanceOf[msg.sender];
```

This might look like the following opcodes:

```
CALLER  -- load msg.sender to the stack
MSTORE  -- push msg.sender to memory
SHA3    -- run sha3 of msg.sender
SLOAD   -- load from that address
```

The trace code can analyze this and realize that the SLOAD matched with that line of code looks like:

`SLOAD(SHA3(sender))`

The goal of the tracing utilities are to bring this analysis into your test cases to verify the code works as expected, thus you could run a trace:

```javascript
saddle.trace(getBalanceReceipt, {
  preFilter: ({op}) => op === 'SLOAD', // ignore any op code that isn't a storage load
  postFilter: (log) => log.source.includes('balanceOf[msg.sender]'), // filter to storage loads that match this line of code
  exec: (logs) => {
    expect(logs.length).toEqual(1); // check that there is exactly one storage load associated with the line of code
  }
});
```

But that's only the beginning. There's a ton more than can be done and built. Hopefully tracing can be a big part of answering "I think this is what Solidity does, but I'm not sure"-type questions.