### PR TITLE
0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "typescript": "^3.5.1",
     "web3": "^1.2.4",
     "web3-provider-engine": "^15.0.4",
-    "web3-providers": "^1.0.0-beta.55",
     "yargs": "^13.2.4"
   },
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import Web3 from 'web3';
-import { HttpProvider } from 'web3-providers';
 import { SendOptions } from 'web3-eth-contract';
 import path from 'path';
 import ganache from 'ganache-core';

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,9 +86,9 @@ export async function loadConfig(file?: string, trace?: boolean): Promise<Saddle
   };
 }
 
-async function fetchProvider(source: ProviderSource): Promise<HttpProvider | ganache.Provider | undefined> {
+async function fetchProvider(source: ProviderSource): Promise<string | ganache.Provider | undefined> {
   function maybeProvider(source: string | undefined) {
-    return source && source.length > 0 ? new HttpProvider(source) : undefined;
+    return source && source.length > 0 ? source.trim() : undefined;
   }
 
   if (!source) {
@@ -127,7 +127,7 @@ async function fetchAccount(source: AccountSource, web3: Web3): Promise<string |
     }
   } else if ('file' in source) {
     try {
-      let privateKey = await readFile(source.file, 'utf8');
+      let privateKeys = await readFile(source.file, 'utf8');
       let account = web3.eth.accounts.wallet.add('0x' + privateKey.trim());
       return account.address;
     } catch (e) {
@@ -208,7 +208,7 @@ export async function instantiateConfig(config: SaddleConfig, network: string): 
 
   let artifactAdapter;
   if (config.trace) {
-    artifactAdapter = new SaddleArtifactAdapter(config.build_dir, 'contracts-trace.json', config.coverage_ignore); 
+    artifactAdapter = new SaddleArtifactAdapter(config.build_dir, 'contracts-trace.json', config.coverage_ignore);
   }
 
   const {account, web3, defaultOptions, cov, providerEngine} = await fetchWeb3(arr(networkConfig.providers), arr(networkConfig.accounts), networkConfig.web3, artifactAdapter, config);

--- a/src/saddle.ts
+++ b/src/saddle.ts
@@ -9,7 +9,8 @@ import { buildTracer, TraceOptions } from './trace';
 
 export interface Saddle {
   account: string,
-  accounts: string[]
+  accounts: string[],
+  wallet_accounts: string[],
   saddle_config: SaddleConfig
   network_config: NetworkConfig
   getContract: (contractName: string, sendOptions: SendOptions) => Promise<Contract>
@@ -103,8 +104,9 @@ export async function getSaddle(network, trace=false): Promise<Saddle> {
   }
 
   return {
-    account: network_config.account,
+    account: network_config.default_account,
     accounts: await network_config.web3.eth.getAccounts(),
+    wallet_accounts: network_config.wallet_accounts,
     saddle_config: saddle_config,
     network_config: network_config,
     deploy: deploy,


### PR DESCRIPTION
* patches web3 http provider bug. basically, passing  a provider url would cause saddle to create its own web3 http provider, but it was doing so with a version of `web3-provider` is presumably incompatible with our version of web3 `1.0.beta55`. Instead, we just pass web3 the url and let it figure it out. Probably worth looking back and fixing using `web3-provider-engine`, but this works for now. 

* reads multiple private keys and adds them to the web3 wallet. Use this by adding multiple keys to `~/ethereum/${network}`, separating each with a newline