### PR TITLE
Allow Multiple Build Files and Add Import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "^24.0.15",
     "ethereumjs-tx": "2.1.2",
     "ethereumjs-util": "5.2.0",
+    "fast-glob": "^3.2.2",
     "ganache-core": "^2.9.1",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",

--- a/saddle.config.js
+++ b/saddle.config.js
@@ -6,6 +6,7 @@ module.exports = {
     maxBuffer: 1024 * 5000                              // https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
   },
   build_dir: ".build",                                  // Directory to place built contracts
+  extra_build_files: [],                                // Additional build files to deep merge
   coverage_dir: "coverage",                             // Directory to place coverage files
   coverage_ignore: [],                                  // List of files to ignore for coverage
   contracts: "contracts/*.sol",                         // Glob to match contract files

--- a/src/cli/commands/etherscan.ts
+++ b/src/cli/commands/etherscan.ts
@@ -1,0 +1,63 @@
+import request from 'request';
+
+export interface Result {
+  status: string
+  message: string
+  result: string
+}
+
+export function getEtherscanApiUrl(network: string): string {
+  let host = {
+    kovan: 'api-kovan.etherscan.io',
+    rinkeby: 'api-rinkeby.etherscan.io',
+    ropsten: 'api-ropsten.etherscan.io',
+    goerli: 'api-goerli.etherscan.io',
+    mainnet: 'api.etherscan.io'
+  }[network];
+
+  if (!host) {
+    throw new Error(`Unknown etherscan API host for network ${network}`);
+  }
+
+  return `https://${host}/api`;
+}
+
+export function getEtherscanUrl(network: string): string {
+  let host = {
+    kovan: 'kovan.etherscan.io',
+    rinkeby: 'rinkeby.etherscan.io',
+    ropsten: 'ropsten.etherscan.io',
+    goerli: 'goerli.etherscan.io',
+    mainnet: 'etherscan.io'
+  }[network];
+
+  if (!host) {
+    throw new Error(`Unknown etherscan host for network ${network}`);
+  }
+
+  return `https://${host}`;
+}
+
+export function post(url, data): Promise<object> {
+  return new Promise((resolve, reject) => {
+    request.post(url, {form: data}, (err, httpResponse, body) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(JSON.parse(body));
+      }
+    });
+  });
+}
+
+export function get(url, data, parser: any=JSON.parse): Promise<object | string> {
+  return new Promise((resolve, reject) => {
+    request.get(url, {form: data}, (err, httpResponse, body) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(parser ? parser(body): body);
+      }
+    });
+  });
+}

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -1,0 +1,112 @@
+import * as util from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Result, get, getEtherscanApiUrl, getEtherscanUrl } from './etherscan';
+
+export async function loadContract(source: string, network: string, address: string, outdir: string, verbose: number) {
+  switch(source) {
+    case 'etherscan':
+      return await loadEtherscanContract(network, address, outdir, verbose);
+    default:
+      throw new Error(`Unknown source \`${source}\`, expected one of [etherscan]`);
+  }
+}
+
+interface EtherscanSource {
+  SourceCode: string,
+  ABI: string,
+  ContractName: string,
+  CompilerVersion: string,
+  OptimizationUsed: string,
+  Runs: string,
+  ConstructorArguments: string,
+  Library: string,
+  LicenseType: string,
+  SwarmSource: string
+}
+
+async function getEtherscanApiData(network: string, address: string) {
+  let apiUrl = await getEtherscanApiUrl(network);
+  let result: Result = <Result>await get(apiUrl, { module: 'contract', action: 'getsourcecode', address });
+
+  if (result.status !== '1') {
+    throw new Error(`Etherscan Error: ${result.message}`);
+  }
+
+  let s = <EtherscanSource><unknown>result.result[0];
+
+  if (s.ABI === "Contract source code not verified") {
+    throw new Error("Contract source code not verified");
+  }
+
+  return {
+    source: s.SourceCode,
+    abi: JSON.parse(s.ABI),
+    contract: s.ContractName,
+    compiler: s.CompilerVersion,
+    optimized: s.OptimizationUsed !== '0',
+    optimzationRuns: Number(s.Runs),
+    constructorArgs: s.ConstructorArguments
+  };
+}
+
+async function getContractCreationCode(network: string, address: string) {
+  let url = `${await getEtherscanUrl(network)}/address/${address}#code`;
+  let result = <string>await get(url, {}, null);
+  let regex = /<div id='verifiedbytecode2'>[\s\r\n]*([0-9a-fA-F]*)[\s\r\n]*<\/div>/g;
+  let matches = [...result.matchAll(regex)];
+  if (matches.length === 0) {
+    throw new Error('Failed to pull deployed contract code from Etherscan');
+  }
+
+  return matches[0][1];
+}
+
+export async function loadEtherscanContract(network: string, address: string, outdir: string, verbose: number) {
+  // Okay, this is where the fun begins, let's gather as much information as we can
+
+  let {
+    source,
+    abi,
+    contract,
+    compiler,
+    optimized,
+    optimzationRuns,
+    constructorArgs
+  } = await getEtherscanApiData(network, address);
+
+  let contractCreationCode = await getContractCreationCode(network, address);
+  let encodedABI = JSON.stringify(abi);
+  let contractSource = `contracts/${contract}.sol:${contract}`;
+
+  let contractBuild = {
+    contracts: {
+      [contractSource]: {
+        abi: encodedABI,
+        bin: contractCreationCode,
+        metadata: JSON.stringify({
+          compiler: {
+            version: compiler
+          },
+          language: "Solidity",
+          output: {
+            abi: encodedABI
+          },
+          devdoc: {},
+          sources: {
+            [contractSource]: {
+              content: source,
+              keccak256: ""
+            }
+          },
+          version: 1
+        })
+      }
+    },
+    version: compiler
+  };
+
+  let outfile = path.join(outdir, `${contract}.json`);
+
+  await util.promisify(fs.writeFile)(outfile, JSON.stringify(contractBuild, null, 2));
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export interface SaddleConfig {
   solc_args: string[]
   solc_shell_args: object
   build_dir: string
+  extra_build_files: string[]
   coverage_dir: string
   coverage_ignore: string[]
   contracts: string
@@ -63,6 +64,7 @@ export interface NetworkConfig {
   solc_args: string[]
   solc_shell_args: object
   build_dir: string
+  extra_build_files: string[]
   coverage_dir: string
   coverage_ignore: string[]
   contracts: string
@@ -238,6 +240,7 @@ export async function instantiateConfig(config: SaddleConfig, network: string): 
     solc_args: config.solc_args,
     solc_shell_args: config.solc_shell_args,
     build_dir: config.build_dir,
+    extra_build_files: config.extra_build_files,
     coverage_dir: config.coverage_dir,
     coverage_ignore: config.coverage_ignore,
     contracts: config.contracts,

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,27 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.72.0.tgz#43df23af013ad1135407e5cf33ca6e4c4c7708d5"
   integrity sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1933,7 +1954,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3909,6 +3930,18 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
+fast-glob@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
+  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -3923,6 +3956,13 @@ fast-safe-stringify@^2.0.6:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -4304,7 +4344,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
   integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
@@ -6285,6 +6325,11 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
+  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
 merkle-patricia-tree@2.3.2, merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz#982ca1b5a0fde00eed2f6aeed1f9152860b8208a"
@@ -6322,6 +6367,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -7057,7 +7110,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.7:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
@@ -7742,6 +7795,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -7768,6 +7826,11 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 rustbn.js@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This patch allows configurers to set multiple build files, which will be merged together (which effectively lets us deploy from multiple separate compilations). This allows users of Saddle to have builds from multiple versions of Solidity, etc.

Additionally, we add a new command `saddle import -n network 0x...` which will import the contract at the given address 0x... from Etherscan as a new build file. This will allow users to effectly clone a deployed contract by importing it to a build file and then calling `deploy` to deploy that contract to a different network (e.g. development or another testnet, etc). What's really cool is: you're not compiling and trying to redeploy that contract-- you're deploying the exact bytecode that was deployed to the network you imported from. This should significantly reduce the risk that the production version differs from our test version.