### PR TITLE
trace opcode fix refactored - 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -144,7 +144,6 @@ export async function buildTracer(network_config: NetworkConfig) {
     }
 
     let { logs: augmentedLogs, info: info } = augmentLogs(trace.structLogs, traceOpts.constants || {});
-    let callLog = {gasRemaining: 0, index: 0};
     let filteredLogs = traceOpts.preFilter ? augmentedLogs.filter(traceOpts.preFilter) : augmentedLogs;
     if (pcToSourceRange && inverted) {
       ({logs: filteredLogs} = await filteredLogs.reduce(async (acc, log, i, allLogs) => {

--- a/src/trace/descriptor.ts
+++ b/src/trace/descriptor.ts
@@ -36,7 +36,17 @@ export function augmentLogs(logs: StructLog[], constants: object): { logs: Log[]
     const nextStack = nextLog ? nextLog.stack : undefined;
 
     let { extended, info: nInfo } = describeOperation(log, nextStack || [], info);
-    const nLog: Log = new Log(log, extended, info.lastLog);
+    let nLog: Log = new Log(log, extended, info.lastLog);
+
+    if (nextLog != undefined) {
+      nLog.gasCost = nextLog.gasCost;
+    }
+
+    if (["STATICCALL", "DELEGATECALL", "CALL"].includes(log.op)) {
+      nLog.gasCost = 700;
+    } else if (log.op == "RETURN") {
+      nLog.gasCost = 0;
+    }
 
     return {
       logs: [...logs, nLog],
@@ -45,5 +55,6 @@ export function augmentLogs(logs: StructLog[], constants: object): { logs: Log[]
         lastLog: nLog
       }
     };
+
   }, <{logs: Log[], info: TraceInfo}>{logs: [], info: { inv, sha: {} }});
 }

--- a/src/trace/descriptor.ts
+++ b/src/trace/descriptor.ts
@@ -36,17 +36,7 @@ export function augmentLogs(logs: StructLog[], constants: object): { logs: Log[]
     const nextStack = nextLog ? nextLog.stack : undefined;
 
     let { extended, info: nInfo } = describeOperation(log, nextStack || [], info);
-    let nLog: Log = new Log(log, extended, info.lastLog);
-
-    // if (nextLog != undefined) {
-    //   nLog.gasCost = nextLog.gasCost;
-    // }
-
-    // if (["STATICCALL", "DELEGATECALL", "CALL"].includes(log.op)) {
-    //   nLog.gasCost = 700;
-    // } else if (log.op == "RETURN") {
-    //   nLog.gasCost = 0;
-    // }
+    const nLog: Log = new Log(log, extended, info.lastLog);
 
     return {
       logs: [...logs, nLog],
@@ -55,6 +45,5 @@ export function augmentLogs(logs: StructLog[], constants: object): { logs: Log[]
         lastLog: nLog
       }
     };
-
   }, <{logs: Log[], info: TraceInfo}>{logs: [], info: { inv, sha: {} }});
 }

--- a/src/trace/descriptor.ts
+++ b/src/trace/descriptor.ts
@@ -38,15 +38,15 @@ export function augmentLogs(logs: StructLog[], constants: object): { logs: Log[]
     let { extended, info: nInfo } = describeOperation(log, nextStack || [], info);
     let nLog: Log = new Log(log, extended, info.lastLog);
 
-    if (nextLog != undefined) {
-      nLog.gasCost = nextLog.gasCost;
-    }
+    // if (nextLog != undefined) {
+    //   nLog.gasCost = nextLog.gasCost;
+    // }
 
-    if (["STATICCALL", "DELEGATECALL", "CALL"].includes(log.op)) {
-      nLog.gasCost = 700;
-    } else if (log.op == "RETURN") {
-      nLog.gasCost = 0;
-    }
+    // if (["STATICCALL", "DELEGATECALL", "CALL"].includes(log.op)) {
+    //   nLog.gasCost = 700;
+    // } else if (log.op == "RETURN") {
+    //   nLog.gasCost = 0;
+    // }
 
     return {
       logs: [...logs, nLog],


### PR DESCRIPTION
refactors #22 to add dynamically calculated external call opcode costs, putting the logic next to our other call stack logic. 

basically: all gasCosts are 1 off (the next opcode shows the previous opcodes gas cost).

basically2: the gas cost for calls (`STATICCALL`, `DELEGATECALL`, `CALL`, etc) is the total remaining gas in the tx, and the `RETURN` opcode shows the "refund" for the gas not used. so if we add the two together, we should get the real cost. before, we just hardcoded this number to 700 