### PR TITLE
Saddle Scripts 0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,29 @@ Available commands:
 
 You can recompile contracts in the repl by running `.compile`.
 
+## Scripts
+
+You can also run scripts from saddle. For instance, you can run:
+
+```bash
+npx saddle script myScript.js arg0 arg1
+```
+
+And then if you have a script such as:
+
+```javascript
+// my_script.js
+
+const [name, symbol] = args;
+
+async function() {
+  let contract = await saddle.deploy('MyContract', [name, symbol]);
+  console.log(`Deployed MyContract to ${contract.address}`);
+}();
+```
+
+This should open up the ability to create complex deployment scripts.
+
 ## Configuration
 
 Saddle comes with reasonable default configuration, but you can override it. The core of the configuration is a list of "sources" for any given configuration-item, allowing the framework to look at say an environment variable for a provider, or if that is missing, a file with the provider information, or if that is missing, use a default http endpoint. This would be described as:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/saddle.config.js
+++ b/saddle.config.js
@@ -111,5 +111,6 @@ module.exports = {
         {file: "~/.ethereum/ropsten"}                   // Load from given file with contents as the private key (e.g. 0x...)
       ]
     }
-  }
+  },
+  scripts: {}                                           // Aliases for scripts
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,10 +162,14 @@ export function getCli() {
 
       loadContract(argv.source, argv.network, address, argv.outdir, argv.verbose);
     })
-    .command('verify <apiKey> <contract>', 'Verify a given contract on Etherscan', (yargs) => {
+    .command('verify <apiKey> <address> <contract>', 'Verify a given contract on Etherscan', (yargs) => {
       return yargs
         .positional('apiKey', {
           describe: 'API Key from Etherscan',
+          type: 'string'
+        })
+        .positional('address', {
+          describe: 'Address of contract to verify',
           type: 'string'
         })
         .positional('contract', {
@@ -177,10 +181,6 @@ export function getCli() {
           type: 'number',
           default: 200
         })
-        .option('source', {
-          describe: 'Name of contract to read source from',
-          type: 'string'
-        })
         .option('raw', {
           alias: 'r',
           describe: 'Args should be passed-through without transformation',
@@ -189,12 +189,13 @@ export function getCli() {
         });
     }, (argv) => {
       const apiKey: string = <string>argv.apiKey; // required
+      const address: string = <string>argv.address; // required
       const contract: string = <string>argv.contract; // required
       const optimizations: number = <number>argv.optimizations; // required
       const [,...contractArgsRaw] = argv._;
       const contractArgs = argv.raw ? argv._[1] : transformArgs(contractArgsRaw);
 
-      etherscanVerify(argv.network, apiKey, contract, contractArgs, optimizations, argv.source, argv.verbose);
+      etherscanVerify(argv.network, apiKey, address, contract, contractArgs, optimizations, argv.verbose);
     })
     .command('test', 'Run contract tests', (yargs) => yargs, (argv) => {
       test(argv, false, argv.verbose);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { match } from './cli/commands/match';
 import { etherscanVerify } from './cli/commands/verify';
 import { init } from './cli/commands/init';
 import { test } from './cli/commands/test';
+import { runScript } from './cli/commands/script';
 export { getSaddle, Saddle } from './saddle';
 import { Readable, pipeline } from 'stream';
 import { createReadStream } from 'fs';
@@ -93,6 +94,17 @@ export function getCli() {
     })
     .command('contracts', 'Display given contracts', (yargs) => yargs, (argv) => {
       argv.contractsResult = listContracts(argv.network);
+    })
+    .command('script <script>', 'Run a given script', (yargs) => {
+      return yargs
+        .positional('script', {
+          describe: 'Script to run',
+          type: 'string'
+        });
+    }, (argv) => {
+      const script: string = <string>argv.script; // required
+
+      argv.scriptResult = runScript(argv.network, script, argv._.slice(1), argv.verbose);
     })
     .command('deploy <contract>', 'Deploy a contract to given network', (yargs) => {
       return yargs

--- a/src/cli/commands/console.ts
+++ b/src/cli/commands/console.ts
@@ -27,7 +27,7 @@ async function wrapError(p, that) {
   }
 }
 
-async function getContracts(saddle) {
+export async function getContracts(saddle) {
   let contracts = await saddle.listContracts();
   let contractInsts = await Object.entries(contracts).reduce(async (acc, [contract, address]) => {
     if (address) {

--- a/src/cli/commands/script.ts
+++ b/src/cli/commands/script.ts
@@ -26,7 +26,9 @@ export async function runScript(network: string, script: string, scriptArgs: any
     ...contractAddresses,
     console,
     network,
-    args: scriptArgs
+    args: scriptArgs,
+    env: process.env,
+    setTimeout
   };
 
   let scriptFile = saddle.saddle_config.scripts[script] || script; 

--- a/src/cli/commands/script.ts
+++ b/src/cli/commands/script.ts
@@ -1,0 +1,53 @@
+import util from 'util';
+import vm from 'vm';
+
+import { readFile } from '../../file';
+import { getSaddle } from '../../saddle';
+import { getContracts } from './console';
+
+import { info, debug, warn, error } from '../logger';
+import { describeProvider } from '../../utils';
+
+export async function runScript(network: string, script: string, scriptArgs: any[], verbose: number): Promise<any> {
+  let saddle = await getSaddle(network);
+  let {contracts, contractInsts} = await getContracts(saddle);
+  let contractAddresses = Object.fromEntries(
+    Object.entries(contracts).map(([contract, address]) => {
+      return [`$${contract}`, address];
+    }));
+
+  info(`Running script ${script} on network ${network} ${describeProvider(saddle.web3.currentProvider)} with args ${JSON.stringify(scriptArgs)}`, verbose);
+
+  const context = {
+    saddle,
+    ...saddle,
+    ...contractInsts,
+    addresses: contracts,
+    ...contractAddresses,
+    console,
+    network,
+    args: scriptArgs
+  };
+
+  let scriptFile = saddle.saddle_config.scripts[script] || script; 
+  const scriptContents = await readFile(scriptFile, null, (x) => x.toString());
+  if (!scriptContents) {
+    throw new Error(`Script not found: ${scriptFile}`);
+  }
+
+  const vmScript = new vm.Script(scriptContents);
+
+  vm.createContext(context);
+
+  let start = +new Date();
+  let result = await vmScript.runInContext(context);
+  let end = +new Date();
+
+  info(`Script finished in ${end - start}ms.`, verbose);
+  if (result) {
+    debug("Script Result:", verbose);
+    debug(result, verbose);
+  }
+
+  return result;
+}

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -70,17 +70,12 @@ function getConstructorABI(abi: {type: string, inputs: any[]}[], contractArgs: (
   }
 }
 
-export async function etherscanVerify(network: string, apiKey: string, contractName: string, contractArgs: (string|string[])[], optimizations: number, source: string | undefined, verbose: number): Promise<void> {
-  info(`Verifying contract ${contractName}${source ? ` from ${source}`: ""} with args ${JSON.stringify(contractArgs)}`, verbose);
+export async function etherscanVerify(network: string, apiKey: string, address: string, contractName: string, contractArgs: (string|string[])[], optimizations: number, verbose: number): Promise<void> {
+  info(`Verifying contract ${contractName} at ${address} with args ${JSON.stringify(contractArgs)}`, verbose);
 
   let saddle = await getSaddle(network);
 
-  let contractAddress = await loadContractAddress(contractName, saddle.network_config);
-  if (!contractAddress) {
-    throw new Error(`Cannot find contract ${contractName}- was it deployed to ${network}?`);
-  }
-  let contractSource = source || contractName;
-  let contractBuild = await getContractBuild(contractSource, saddle.saddle_config);
+  let contractBuild = await getContractBuild(contractName, saddle.saddle_config);
   let metadata = JSON.parse((<any>contractBuild).metadata);
   let compilerVersion: string = contractBuild.version.replace(/(\.Emscripten)|(\.clang)|(\.Darwin)|(\.appleclang)/gi, '');
   let constructorAbi = Array.isArray(contractArgs) ? getConstructorABI(JSON.parse(contractBuild.abi), contractArgs) : contractArgs;
@@ -96,14 +91,14 @@ export async function etherscanVerify(network: string, apiKey: string, contractN
     module: 'contract',
     action: 'verifysourcecode',
     codeformat: 'solidity-standard-json-input',
-    contractaddress: contractAddress,
+    contractaddress: address,
     sourceCode: JSON.stringify({language, settings, sources}),
     contractname: target,
     compilerversion: `v${compilerVersion}`,
     constructorArguements: constructorAbi.slice(2)
   };
 
-  info(`Verifying ${contractName} at ${contractAddress} with compiler version ${compilerVersion}...`, verbose);
+  info(`Verifying ${contractName} at ${address} with compiler version ${compilerVersion}...`, verbose);
   debug(`Etherscan API Request:\n\n${JSON.stringify(verifyData, undefined, 2)}`, verbose);
   debug(metadata.sources, verbose);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ export interface SaddleConfig {
   contracts: string
   tests: string[]
   networks: {[network: string]: SaddleNetworkConfig}
+  scripts: {[name: string]: string}
   trace: boolean
   get_build_file?: () => string
   read_build_file?: () => Promise<object>


### PR DESCRIPTION
This patch adds the ability to run scripts via saddle. Scripts are as simple as JavaScript files that can use `saddle` and the associated commands. This makes it easy to do `saddle script myScript.js` and encapsulate any arbitrary logic in there. To make it even easier, you can alias scripts in your saddle config so you can just run `saddle script myScript` and it will choose the right path. Finally, you can pass args to your scripts so you can run `saddle script myScript arg0 arg1 arg2` and use those args from within your script. This should hopefully be useful for people making more complex deployment scripts, etc.