### PR TITLE
Rework Verify Command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,10 +162,14 @@ export function getCli() {
 
       loadContract(argv.source, argv.network, address, argv.outdir, argv.verbose);
     })
-    .command('verify <apiKey> <contract>', 'Verify a given contract on Etherscan', (yargs) => {
+    .command('verify <apiKey> <address> <contract>', 'Verify a given contract on Etherscan', (yargs) => {
       return yargs
         .positional('apiKey', {
           describe: 'API Key from Etherscan',
+          type: 'string'
+        })
+        .positional('address', {
+          describe: 'Address of contract to verify',
           type: 'string'
         })
         .positional('contract', {
@@ -177,10 +181,6 @@ export function getCli() {
           type: 'number',
           default: 200
         })
-        .option('source', {
-          describe: 'Name of contract to read source from',
-          type: 'string'
-        })
         .option('raw', {
           alias: 'r',
           describe: 'Args should be passed-through without transformation',
@@ -189,12 +189,13 @@ export function getCli() {
         });
     }, (argv) => {
       const apiKey: string = <string>argv.apiKey; // required
+      const address: string = <string>argv.address; // required
       const contract: string = <string>argv.contract; // required
       const optimizations: number = <number>argv.optimizations; // required
       const [,...contractArgsRaw] = argv._;
       const contractArgs = argv.raw ? argv._[1] : transformArgs(contractArgsRaw);
 
-      etherscanVerify(argv.network, apiKey, contract, contractArgs, optimizations, argv.source, argv.verbose);
+      etherscanVerify(argv.network, apiKey, address, contract, contractArgs, optimizations, argv.verbose);
     })
     .command('test', 'Run contract tests', (yargs) => yargs, (argv) => {
       test(argv, false, argv.verbose);

--- a/src/cli/commands/script.ts
+++ b/src/cli/commands/script.ts
@@ -26,7 +26,9 @@ export async function runScript(network: string, script: string, scriptArgs: any
     ...contractAddresses,
     console,
     network,
-    args: scriptArgs
+    args: scriptArgs,
+    env: process.env,
+    setTimeout
   };
 
   let scriptFile = saddle.saddle_config.scripts[script] || script; 

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -135,17 +135,12 @@ function getConstructorABI(abi: {type: string, inputs: any[]}[], contractArgs: (
   }
 }
 
-export async function etherscanVerify(network: string, apiKey: string, contractName: string, contractArgs: string | any[], optimizations: number, source: string | undefined, verbose: number): Promise<void> {
-  info(`Verifying contract ${contractName}${source ? ` from ${source}`: ""} with args ${JSON.stringify(contractArgs)}`, verbose);
+export async function etherscanVerify(network: string, apiKey: string, address: string, contractName: string, contractArgs: string | any[], optimizations: number, verbose: number): Promise<void> {
+  info(`Verifying contract ${contractName} at ${address} with args ${JSON.stringify(contractArgs)}`, verbose);
 
   let saddle = await getSaddle(network);
 
-  let contractAddress = await loadContractAddress(contractName, saddle.network_config);
-  if (!contractAddress) {
-    throw new Error(`Cannot find contract ${contractName}- was it deployed to ${network}?`);
-  }
-  let contractSource = source || contractName;
-  let contractBuild = await getContractBuild(contractSource, saddle.saddle_config);
+  let contractBuild = await getContractBuild(contractName, saddle.saddle_config);
   let metadata = JSON.parse((<any>contractBuild).metadata);
   let sourceCode: string = await flattenSources(metadata.sources, contractName);
   let compilerVersion: string = contractBuild.version.replace(/(\.Emscripten)|(\.clang)|(\.Darwin)|(\.appleclang)/gi, '');
@@ -156,7 +151,7 @@ export async function etherscanVerify(network: string, apiKey: string, contractN
     apikey: apiKey,
     module: 'contract',
     action: 'verifysourcecode',
-    contractaddress: contractAddress,
+    contractaddress: address,
     sourceCode: sourceCode,
     contractname: contractName,
     compilerversion: `v${compilerVersion}`,
@@ -165,7 +160,7 @@ export async function etherscanVerify(network: string, apiKey: string, contractN
     constructorArguements: constructorAbi.slice(2)
   };
 
-  info(`Verifying ${contractName} at ${contractAddress} with compiler version ${compilerVersion}...`, verbose);
+  info(`Verifying ${contractName} at ${address} with compiler version ${compilerVersion}...`, verbose);
   debug(`Etherscan API Request:\n\n${JSON.stringify(verifyData, undefined, 2)}`, verbose);
   debug(sourceCode, verbose);
 

--- a/src/saddle.ts
+++ b/src/saddle.ts
@@ -6,6 +6,7 @@ import { Contract, SendOptions } from 'web3-eth-contract';
 import { describeProvider } from './utils';
 import { TransactionReceipt } from 'web3-core';
 import { buildTracer, TraceOptions } from './trace';
+import { etherscanVerify } from './cli/commands/verify';
 
 export interface Saddle {
   account: string,
@@ -18,6 +19,7 @@ export interface Saddle {
   listContracts: () => Promise<{[contract: string]: string | null}>
   deploy: (contract: string, args: any[], sendOptions: any) => Promise<Contract>
   deployFull: (contract: string, args: any[], sendOptions: any, web3?: Web3 | undefined) => Promise<{contract: Contract, receipt: TransactionReceipt}>
+  verify: (apiKey: string, address: string, contractName: string, contractArgs: string | any[], optimizations: number) => Promise<void>
   abi: (contract: string) => Promise<AbiItem[]>
   web3: Web3
   send: (contract: Contract, method: string, args: any[], sendOptions?: SendOptions) => Promise<any>
@@ -84,6 +86,11 @@ export async function getSaddle(network, trace=false, quiet=false): Promise<Sadd
     return await deployContract(web3 || network_config.web3, network_config.network, contractName, args, network_config, network_config.defaultOptions, options);
   }
 
+  // TODO: Should this call into CLI code or maybe we should factor into a general util module?
+  async function verify(apiKey: string, address: string, contractName: string, contractArgs: string | any[], optimizations: number): Promise<void> {
+    return etherscanVerify(network, apiKey, address, contractName, contractArgs, optimizations, 0);
+  }
+
   async function call(contract: Contract, method: string, args: any[] | SendOptions=[], callOptions?: SendOptions, blockNumber?: number): Promise<any> {
     [args, callOptions] = allowUndefinedArgs(args, callOptions);
 
@@ -117,6 +124,7 @@ export async function getSaddle(network, trace=false, quiet=false): Promise<Sadd
     saddle_config: saddle_config,
     network_config: network_config,
     deploy: deploy,
+    verify: verify,
     deployFull: deployFull,
     abi: abi,
     web3: network_config.web3,


### PR DESCRIPTION
This patch reworks the Verify command to accept an address instead of a contract name. This just seems easier overall than trying to manage the deployed mappings to use this function. We should sit and take a hard look at the command signatures and make sure they align with what we're looking for.