### PR TITLE
Improvements to Verify, Bump to 0.1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Let's assume you define a simple Ethereum contract:
 
 `contracts/MyContract.sol`
 
-```javascript
-pragma solidity ^0.5.12;
+```solidity
+pragma solidity ^0.5.16;
 
 contract MyContract {
 	function myFunc() pure external returns (uint256) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.16-alpha2",
+  "version": "0.1.16",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,13 +8,11 @@ export function warn(message: string, verbose: number) {
 }
 
 export function info(message: string, verbose: number) {
-  if (verbose >= 1) {
-    console.log(message);
-  }
+  console.log(message);
 }
 
 export function debug(message: string, verbose: number) {
-  if (verbose >= 2) {
+  if (verbose >= 1) {
     console.log(message);
   }
 }


### PR DESCRIPTION
This patch adds a number of improvements to Verify to 1) allow all solc versions by stripping everything after the commit hash, 2) add license support (currently set to NO LICENSE), and 3) make sure our checks have a proper API key. Additionally, we fix verbosity as `info` is expected to show without `v` in the current implementations. Finally, we bump to 0.1.16.