### PR TITLE
Add struct argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,24 @@ provider: [{env: "PROVIDER"}, {file: "~/.ethereum-provider"}, {http: "http://rin
 
 To set your own configuration, simply run: `saddle init` and this will create a file `saddle.config.js`. Make any changes to the configuration you need in that file
 
+## How to build and use saddle package locally 
+1. Building and linking saddle package for local usage: 
+```bash
+yarn install
+yarn prepare 
+yarn link
+```
+
+2. Linking locally built saddle package inside the project where you want to use it: 
+```bash
+yarn link "eth-saddle"
+```
+
+3. To reverse linking process, simply use:
+```bash 
+yarn unlink "eth-saddle"
+```
+
 ## Contributing
 
 Please create an issue for any questions. In the interest of keeping saddle as simple as possible, we will not try to mimic all features of more complex frameworks-- so it's better to discuss first before submitting PRs.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,15 +18,19 @@ import { createReadStream } from 'fs';
 function transformArgs(contractArgsRaw) {
   const transformers = {
     array: (arg) => arg.split(',').filter(x => x.length > 0),
-    address: (arg) => arg.toString()
+    address: (arg) => arg.toString(),
+    struct: (arg) => JSON.parse(arg)
   };
 
   return contractArgsRaw.map((arg) => {
-    let [raw, type] = arg.toString().split(':', 2);
-
+    // Split based on the last occurance of ':', very import for struct type
+    let [raw, type] = arg.toString().split(/\:(?=[^\:]+$)/)
+    
     if (!type) {
       if (Number.isInteger(arg)) {
         type = 'number';
+      } else if (arg.includes('{') && arg.includes('}')) {
+        type = 'struct';
       } else if (arg.includes(',')) {
         type = 'array';
       }


### PR DESCRIPTION
Added processing of 'struct' arg to saddle cli. 
Example of usage: `npx saddle deploy SomeContract '{"cEthAddress":"0x0000000000000000000000000000000000000001","cUsdcAddress":"0x0000000000000000000000000000000000000002"}':struct -n test`

Note - The representation of `:struct` arg matches js struct exactly, but I can change it to the way similar to how `:array` is done. For example
`filed1=>value1,field2=>value2:struct` or something like that. 
