### PR TITLE
Remove Optimizations Param, Bump to 0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,11 +176,6 @@ export function getCli() {
           describe: 'Contract to deploy (e.g. myContract.sol)',
           type: 'string'
         })
-        .option('optimizations', {
-          describe: 'Optimizations used in compilation (0=off)',
-          type: 'number',
-          default: 200
-        })
         .option('raw', {
           alias: 'r',
           describe: 'Args should be passed-through without transformation',
@@ -191,11 +186,10 @@ export function getCli() {
       const apiKey: string = <string>argv.apiKey; // required
       const address: string = <string>argv.address; // required
       const contract: string = <string>argv.contract; // required
-      const optimizations: number = <number>argv.optimizations; // required
       const [,...contractArgsRaw] = argv._;
       const contractArgs = argv.raw ? argv._[1] : transformArgs(contractArgsRaw);
 
-      verify(argv.network, apiKey, address, contract, contractArgs, optimizations, argv.verbose);
+      verify(argv.network, apiKey, address, contract, contractArgs, argv.verbose);
     })
     .command('test', 'Run contract tests', (yargs) => yargs, (argv) => {
       test(argv, false, argv.verbose);

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -9,10 +9,10 @@ import { info, debug, warn, error } from '../../logger';
 import { getSaddle } from '../../saddle';
 import { etherscanVerify } from '../../verify';
 
-export async function verify(network: string, apiKey: string, address: string, contractName: string, contractArgs: (string|string[])[], optimizations: number, verbose: number): Promise<void> {
+export async function verify(network: string, apiKey: string, address: string, contractName: string, contractArgs: (string|string[])[], verbose: number): Promise<void> {
   info(`Verifying contract ${contractName} at ${address} with args ${JSON.stringify(contractArgs)}`, verbose);
 
   let saddle = await getSaddle(network);
 
-  etherscanVerify(saddle.saddle_config, network, apiKey, address, contractName, contractArgs, optimizations, verbose);
+  etherscanVerify(saddle.saddle_config, network, apiKey, address, contractName, contractArgs, verbose);
 }

--- a/src/saddle.ts
+++ b/src/saddle.ts
@@ -92,12 +92,12 @@ export async function getSaddle(network, trace=false, quiet=false): Promise<Sadd
     return await deployContract(web3 || network_config.web3, network_config.network, contractName, args, network_config, network_config.defaultOptions, options);
   }
 
-  async function verify(apiKey: string, address: string, contractName: string, contractArgs: (string | string[])[], optimizations: number): Promise<void> {
-    return await etherscanVerify(saddle_config, network, apiKey, address, contractName, contractArgs, optimizations, 1);
+  async function verify(apiKey: string, address: string, contractName: string, contractArgs: (string | string[])[], verbose=0): Promise<void> {
+    return await etherscanVerify(saddle_config, network, apiKey, address, contractName, contractArgs, verbose);
   }
 
-  async function matchInt(address: string, contractName: string, contractArgs: string | any[]): Promise<void> {
-    return await match(network_config, network_config.default_account, network_config.web3, address, contractName, contractArgs, false, 1);
+  async function matchInt(address: string, contractName: string, contractArgs: string | any[], verbose=0): Promise<void> {
+    return await match(network_config, network_config.default_account, network_config.web3, address, contractName, contractArgs, false, 0);
   }
 
   async function call(contract: Contract, method: string, args: any[] | SendOptions=[], callOptions?: SendOptions, blockNumber?: number): Promise<any> {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -87,7 +87,7 @@ function getConstructorABI(abi: {type: string, inputs: any[]}[], contractArgs: (
   }
 }
 
-export async function etherscanVerify(saddle_config: SaddleConfig, network: string, apiKey: string, address: string, contractName: string, contractArgs: (string|string[])[], optimizations: number, verbose: number): Promise<void> {
+export async function etherscanVerify(saddle_config: SaddleConfig, network: string, apiKey: string, address: string, contractName: string, contractArgs: (string|string[])[], verbose: number): Promise<void> {
   info(`Verifying contract ${contractName} at ${address} with args ${JSON.stringify(contractArgs)}`, verbose);
 
   let contractBuild = await getContractBuild(contractName, saddle_config);


### PR DESCRIPTION
This patch removes the optimizations param, as its now pulled from the build file directly. Additionally, we make some fixes to verbosity levels and bump to 0.1.17.