### PR TITLE
Clean up argument types, make deployment of json tuple and array of json tuples more clear

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,25 +12,25 @@ import { init } from './cli/commands/init';
 import { test } from './cli/commands/test';
 import { runScript } from './cli/commands/script';
 export { getSaddle, Saddle } from './saddle';
-import { Readable, pipeline } from 'stream';
+import { isValidJSONString } from './utils';
+import { Readable } from 'stream';
 import { createReadStream } from 'fs';
 
 function transformArgs(contractArgsRaw) {
   const transformers = {
     array: (arg) => arg.split(',').filter(x => x.length > 0),
     address: (arg) => arg.toString(),
-    struct: (arg) => JSON.parse(arg)
+    json: (arg) => JSON.parse(arg)
   };
 
   return contractArgsRaw.map((arg) => {
-    // Split based on the last occurance of ':', very import for struct type
-    let [raw, type] = arg.toString().split(/\:(?=[^\:]+$)/)
-    
+    // Check if arg is valid json string - tuple or an array of tuples,
+    // otherwise split based on the last occurance of ':'
+    let [raw, type] = isValidJSONString(arg) ? [arg, 'json'] : arg.toString().split(/\:(?=[^\:]+$)/);
+
     if (!type) {
       if (Number.isInteger(arg)) {
         type = 'number';
-      } else if (arg.includes('{') && arg.includes('}')) {
-        type = 'struct';
       } else if (arg.includes(',')) {
         type = 'array';
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,3 +75,12 @@ export function describeProvider(provider): string {
     return provider.engine ? provider.engine.constructor.name : 'unknown provider';
   }
 }
+
+export function isValidJSONString(str) {
+  try {
+      JSON.parse(str);
+  } catch (e) {
+      return false;
+  }
+  return true;
+}


### PR DESCRIPTION
An example of how to deploy an array of tuples :

```yarn run deploy UniswapAnchoredView "0xA33....XX" "0x...XX" "0x00" 10 '[{"cToken":"0x0000000000000000000000000000000000000003","underlying":"0x0000000000000000000000000000000000000000","symbolHash":"0x91a08135082b0a28b4ad8ecc7749a009e0408743a9d1cdf34dd6a58d60ee9504","baseUnit":"1000000000000000000","priceSource":2,"fixedPrice":0,"uniswapMarket":"0x99193Ac738C1De168169b27F71045Ebb8d1EfE26","isUniswapReversed":false}]'```

or 

```yarn run deploy UniswapAnchoredView "0xA33....XX" "0x...XX" "0x00" 10 '[{"cToken":"0x0000000000000000000000000000000000000003","underlying":"0x0000000000000000000000000000000000000000","symbolHash":"0x91a08135082b0a28b4ad8ecc7749a009e0408743a9d1cdf34dd6a58d60ee9504","baseUnit":"1000000000000000000","priceSource":2,"fixedPrice":0,"uniswapMarket":"0x99193Ac738C1De168169b27F71045Ebb8d1EfE26","isUniswapReversed":false}]':json```

An example of how to deploy single tuple/struct: 

```yarn run deploy AnchoredView "0x...00" "0x..0" "0x..000" "0x16345785d8a0000" '{"cEthAddress":"0x0000000000000000000000000000000000000001","cUsdcAddress":"0x0000000000000000000000000000000000000002"}':json ```

or 

```yarn run deploy AnchoredView "0x...00" "0x..0" "0x..000" "0x16345785d8a0000" '{"cEthAddress":"0x0000000000000000000000000000000000000001","cUsdcAddress":"0x0000000000000000000000000000000000000002"}'```

