### PR TITLE
Bump to 0.1.21 and Fix JSON-decoding of Numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-saddle",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Ethereum Smart Contract Saddle",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,9 +78,12 @@ export function describeProvider(provider): string {
 
 export function isValidJSONString(str) {
   try {
-      JSON.parse(str);
+    let res = JSON.parse(str);
+
+    return typeof(res) !== 'number';
   } catch (e) {
-      return false;
+    return false;
   }
+
   return true;
 }


### PR DESCRIPTION
This patch fixes encoding numbers; we were parsing them as JSON, which is good, except they could possibly overflow 64-bit floats (which JavaScript uses for numbers) and so we keep them as strings for now. We should convert them to BigInt in the future.